### PR TITLE
Fixed issue with total points per day

### DIFF
--- a/database/prisma/schema.prisma
+++ b/database/prisma/schema.prisma
@@ -122,7 +122,7 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
-//create the activity model
+// create the activity model
 enum ActivityType {
   Lecture
   Workshop
@@ -147,6 +147,7 @@ model Activity {
   date        DateTime
   duration    Int
   location    String       @db.VarChar(80)
+  points      Int?
   validated   Boolean      @default(false)
   type        ActivityType
 

--- a/lib/server/services/student/student.ts
+++ b/lib/server/services/student/student.ts
@@ -360,6 +360,9 @@ export async function addTotalPoints(studentDetails: StudentDetails, totalPoints
           { dateCode: defaultDayCode },
         ],
       },
+      orderBy: {
+        dateCode: currentDayCode === defaultDayCode ? 'asc' : 'desc',
+      },
     });
 
     if (!day) {


### PR DESCRIPTION
## What's the issue this PR is solving?

This PR fixes an issue where the default day (1st of January of 1970) was being chosen instead of the current day code. 

## What are you changing?

In order to fix the issue an orderBy was added in the query that gets the current day.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation