### PR TITLE
Fixed issue with special ratio redeeming

### DIFF
--- a/lib/server/services/student/student.ts
+++ b/lib/server/services/student/student.ts
@@ -288,10 +288,12 @@ export async function requestAward(user: User) {
         )
       }
 
+      const ratio = (await getRedemptionSettings()).RATIO;
+
       return await tx.awardToken.create({
         data: {
           type:
-            studentTx.reedems % (await getRedemptionSettings()).RATIO === 0
+            (studentTx.reedems + (ratio - 1)) % ratio === 0
               ? AwardType.SPECIAL
               : AwardType.NORMAL,
           student: {

--- a/lib/server/services/student/student.ts
+++ b/lib/server/services/student/student.ts
@@ -291,7 +291,7 @@ export async function requestAward(user: User) {
       return await tx.awardToken.create({
         data: {
           type:
-            studentTx.reedems % (await getRedemptionSettings()).RATIO !== 0
+            studentTx.reedems % (await getRedemptionSettings()).RATIO === 0
               ? AwardType.SPECIAL
               : AwardType.NORMAL,
           student: {


### PR DESCRIPTION
## What's the issue this PR is solving?

This issue just fixes a small issue where the SPECIAL ratio was incorrectly being applied. When the rest between the division of the quantity of redeems and ratio is 0 it was returning a NORMAL redeem instead of a SPECIAL redeem.

## What are you changing?

This PR just changes the code to check for the equality of 0 instead of the difference.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
