### PR TITLE
fix: center images for CV, Activities, Event prizes

### DIFF
--- a/_pages/PrizesPage/components/Prize/Prize.tsx
+++ b/_pages/PrizesPage/components/Prize/Prize.tsx
@@ -5,16 +5,21 @@ import { useMediaQuery } from '@mantine/hooks'
 export default function Prize({ title, image, description }: PrizeData) {
   const isMobile = useMediaQuery(`(max-width: ${em(750)})`)
 
+  // Set container size based on screen size
+  const containerClasses = isMobile
+    ? 'w-full h-[320px]'       // On mobile, full width & 320px tall 
+    : 'w-[400px] h-[200px]'    // On desktop, 400px wide & 200px tall
+
   return (
     <Paper
       radius={0}
-      className="relative z-0 overflow-hidden select-none cursor-default grow"
+      className={`relative z-0 overflow-hidden select-none cursor-default grow flex items-center justify-center ${containerClasses}`}
     >
       <Image
         alt="Prémio"
-        h={isMobile ? 320 : 200}
-        w={isMobile ? undefined : 400}
         src={image.src}
+        fit="contain"
+        className="object-center w-full h-full"
       />
       <div className="group absolute inset-0 z-30">
         <div className="absolute inset-0 z-10 bg-[#00415a] opacity-70 sm:opacity-50 transition-all"></div>

--- a/_pages/PrizesPage/components/Tips/Tips.tsx
+++ b/_pages/PrizesPage/components/Tips/Tips.tsx
@@ -7,7 +7,7 @@ const TipsSection = () => {
   return (
     <div className="w-full flex flex-col justify-between items-start gap-10 p-4 sm:p-8 sm:py-14 py-8 bg-[#00415a]">
       <Title className={classes.title}>Como participar</Title>
-      <div className="flex flex-col sm:flex-row gap-8 sm:gap-6">
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-6">
         <Tip
           title="Networking"
           description="Interage com as empresas e faz scan dos códigos QR"


### PR DESCRIPTION
## What's the issue this PR is solving?

On mobile and desktop, prize images had conflicting size rule, causing them to appear misaligned. 
#146 

## What are you changing?

Removed conflicting Mantine height/width props.
Ensured each prize card is centered using flex items-center justify-center.
Updated PrizesPage.tsx to center the prize cards as a group on desktop.


### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Screenshots / Screencasts

![Screenshot 2025-02-19 at 11 51 50](https://github.com/user-attachments/assets/9241a888-0632-449a-a792-049142ce6e4f)

