### PR TITLE
fixed the size of the prize card

### DIFF
--- a/components/PrizeDialog/components/PrizeCard.tsx
+++ b/components/PrizeDialog/components/PrizeCard.tsx
@@ -1,5 +1,5 @@
 import { AwardToken } from '@/lib/frontend/api'
-import { Card, Image, Text, Badge, Button, Group } from '@mantine/core'
+import { Card, Badge } from '@mantine/core'
 import { AwardType } from '@prisma/client'
 import { QRCode } from 'react-qrcode-logo'
 
@@ -10,41 +10,41 @@ interface PrizeCardProps {
 export function PrizeCard({ award }: PrizeCardProps) {
   return (
     <Card
-      className="h-fit !rounded-lg"
       shadow="sm"
       padding="lg"
       radius="md"
       withBorder
+      className="bg-white w-fit mx-auto"
     >
-      <Card.Section>
-        <div className="flex flex-col justify-normal items-center border-t p-2">
+      <Card.Section className="border-b">
+        <div className="flex flex-col items-center p-2">
           {award?.type === AwardType.NORMAL && (
-            <Badge color="blue">{award.award.name}</Badge>
+            <Badge color="blue" className="whitespace-normal break-words px-4"> {award.award.name}</Badge>
           )}
           {award?.type === AwardType.SPECIAL && (
-            <Badge color="indigo">{award.award.name}</Badge>
+            <Badge color="indigo" className="whitespace-normal break-words px-4">{award.award.name}</Badge>
           )}
         </div>
       </Card.Section>
 
-      <Card.Section>
-        <center> {/* FIXME é um martelo, alguém que melhore depois por favor com flex e assim porque estou com sono para testar agora */}
+    <Card.Section className="p-4">
+      <div className="flex flex-col items-center">
         <QRCode
           fgColor="#1C7ED6"
           eyeRadius={5}
           qrStyle="dots"
           value={award?.id}
-        />
-        </center>
+          />
+        </div>
       </Card.Section>
 
-      <Card.Section>
-        <div className="flex flex-col justify-normal items-center border-t p-2">
+      <Card.Section className="border-t">
+        <div className="flex flex-col items-center p-2">
           {award?.type === AwardType.NORMAL && (
-            <Badge color="blue">Brinde normal</Badge>
+            <Badge color="blue" className="whitespace-normal break-words px-4">Brinde normal</Badge>
           )}
           {award?.type === AwardType.SPECIAL && (
-            <Badge color="indigo">Brinde bónus</Badge>
+            <Badge color="indigo" className="whitespace-normal break-words px-4">Brinde bónus</Badge>
           )}
         </div>
       </Card.Section>


### PR DESCRIPTION
## What's the issue this PR is solving?

<!--
When the award name is really long, the white prize card wasn’t wide enough, and the QR code wasn’t staying centered.
-->

## What are you changing?

<!--
Replaced the old <center> tag with Tailwind classes (flex and items-center) for proper centering.
Let the card auto-size to fit longer text so the name doesn’t get cut off.
Ensured the QR code remains centered even if the text is very wide.
-->

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Screenshots / Screencasts

<!--
![Screenshot 2025-02-21 at 22 42 32](https://github.com/user-attachments/assets/295d00ea-cb59-4963-b824-416a7755ac08)
-->
