### PR TITLE
fix redeem all awards bug

### DIFF
--- a/lib/server/services/student/student.ts
+++ b/lib/server/services/student/student.ts
@@ -345,8 +345,6 @@ export async function requestAward(user: User) {
         )
       }
       
-
-      console.log("availablePrizes: ", availablePrizes)
       const selectedPrize = weightedRandomSelection(availablePrizes, awardType);
       
       return await tx.awardToken.create({

--- a/lib/server/services/student/student.ts
+++ b/lib/server/services/student/student.ts
@@ -315,6 +315,12 @@ export async function requestAward(user: User) {
       }
 
       const redeemedPrizeIds = studentTx.redeemedPrizes.map((p) => p.awardId)
+
+      const ratio = (await getRedemptionSettings()).RATIO;
+      const awardType = (studentTx.redeems + (ratio - 1)) % ratio === 0
+      ? AwardType.SPECIAL
+      : AwardType.NORMAL
+
       let availablePrizes = await tx.award.findMany({
         where: {
           id: {
@@ -322,7 +328,8 @@ export async function requestAward(user: User) {
           },
           amountAvailable: {
             gt: 0
-          }
+          },
+          type: awardType
         },
       })
 
@@ -338,10 +345,8 @@ export async function requestAward(user: User) {
         )
       }
       
-      const ratio = (await getRedemptionSettings()).RATIO;
-      const awardType = (studentTx.redeems + (ratio - 1)) % ratio === 0
-      ? AwardType.SPECIAL
-      : AwardType.NORMAL
+
+      console.log("availablePrizes: ", availablePrizes)
       const selectedPrize = weightedRandomSelection(availablePrizes, awardType);
       
       return await tx.awardToken.create({

--- a/lib/server/services/student/student.ts
+++ b/lib/server/services/student/student.ts
@@ -335,7 +335,7 @@ export async function requestAward(user: User) {
 
       if (availablePrizes.length === 0) {
         availablePrizes = await tx.award.findMany({
-          where: { amountAvailable: { gt: 0 } },
+          where: { amountAvailable: { gt: 0 }, type: awardType }
         })
       }
 


### PR DESCRIPTION
## What's the issue this PR is solving?

Fixes a bug where the student could not redeem a normal award when it has already received all the normal awards, and it still had special awards to redeem

## What are you changing?

Change the order of the filter, taking in count the type of the award when checking the available prizes

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
